### PR TITLE
Allow loging in as another user (without logging out of yunohost)

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -124,7 +124,6 @@ chown $app:$app "$final_path/config.json5"
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
-# Start a systemd service
 ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log" --line_match="Server started"
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -69,7 +69,8 @@ ynh_script_progression --message="Installing dependencies..." --weight=6
 ynh_install_nodejs --nodejs_version=$NODEJS_VERSION
 
 # Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" \
+	--package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 #=================================================
 # CREATE DEDICATED USER
@@ -118,11 +119,11 @@ chown $app:$app "$final_path/config.json5"
 ynh_script_progression --message="Building Yarn dependencies... This may take several minutes for a first install." --weight=6
 
 pushd "$final_path" || return 1
-    ynh_use_nodejs ; set "${ynh_node_load_PATH:?}"
-    sudo -u $app env "$ynh_node_load_PATH" yarn
-    sudo -u $app env "$ynh_node_load_PATH" yarn build
-    sudo -u $app env "$ynh_node_load_PATH" yarn install --production --ignore-scripts --prefer-offline
-    ynh_secure_remove --file="$final_path/.cache"
+	ynh_use_nodejs ; set "${ynh_node_load_PATH:?}"
+	sudo -u $app env "$ynh_node_load_PATH" yarn
+	sudo -u $app env "$ynh_node_load_PATH" yarn build
+	sudo -u $app env "$ynh_node_load_PATH" yarn install --production --ignore-scripts --prefer-offline
+	ynh_secure_remove --file="$final_path/.cache"
 popd || return 1
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -172,6 +172,8 @@ then
 	ynh_permission_update --permission="main" --add="visitors"
 fi
 
+ynh_permission_url --permission="main" --auth_header=false
+
 #=================================================
 # RELOAD NGINX
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -46,7 +46,7 @@ test ! -d $final_path \
 #=================================================
 # RESTORE THE NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Restoring the NGINX configuration..."
+ynh_script_progression --message="Restoring the NGINX configuration..." --weight=1
 
 ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -68,6 +68,9 @@ if ynh_legacy_permissions_exists; then
 	ynh_app_setting_delete --app=$app --key=is_public
 fi
 
+# Disable auth_header
+ynh_permission_url --permission="main" --auth_header=false
+
 #=================================================
 # CREATE DEDICATED USER
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -57,8 +57,8 @@ ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
 # If final_path doesn't exist, create it
 if [ -z "$final_path" ]; then
-    final_path="/var/www/$app"
-    ynh_app_setting_set --app=$app --key=final_path --value="$final_path"
+	final_path="/var/www/$app"
+	ynh_app_setting_set --app=$app --key=final_path --value="$final_path"
 fi
 
 # Cleaning legacy permissions
@@ -109,7 +109,7 @@ ynh_install_nodejs --nodejs_version=$NODEJS_VERSION
 
 # Install Yarn
 ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" \
-    --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
+	--package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -131,11 +131,11 @@ ynh_script_progression --message="Rebuilding Yarn dependencies..." --weight=2
 chown -R $app:$app "$final_path"
 
 pushd "$final_path" || return 1
-    ynh_use_nodejs ; set "${ynh_node_load_PATH:?}"
-    sudo -u $app env "$ynh_node_load_PATH" yarn
-    sudo -u $app env "$ynh_node_load_PATH" yarn build
-    sudo -u $app env "$ynh_node_load_PATH" yarn install --production --ignore-scripts --prefer-offline
-    ynh_secure_remove --file="$final_path/.cache"
+	ynh_use_nodejs ; set "${ynh_node_load_PATH:?}"
+	sudo -u $app env "$ynh_node_load_PATH" yarn
+	sudo -u $app env "$ynh_node_load_PATH" yarn build
+	sudo -u $app env "$ynh_node_load_PATH" yarn install --production --ignore-scripts --prefer-offline
+	ynh_secure_remove --file="$final_path/.cache"
 popd || return 1
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -88,8 +88,7 @@ then
 	ynh_setup_source --dest_dir="$final_path"
 fi
 
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
+chmod -R u=rwX,g=rX,o= "$final_path"
 chown -R $app:$app "$final_path"
 
 #=================================================


### PR DESCRIPTION
## Problem

Wetty reads the auth_header and refuses to log in as another user. That's not an acceptable behaviour.

## Solution

Ask Yunohost SSO to NOT define the auth_header HTTP header for this specific app.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
